### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/classroom/nguyenduykhanh/CloneAndConvert/neopost/jQuery-File-Upload-9.12.5/server/gae-python/main.py
+++ b/classroom/nguyenduykhanh/CloneAndConvert/neopost/jQuery-File-Upload-9.12.5/server/gae-python/main.py
@@ -177,8 +177,7 @@ class FileHandler(CORSHandler):
             content_type = 'image/png'
         self.response.headers['Content-Type'] = content_type
         # Cache for the expiration time:
-        self.response.headers['Cache-Control'] = 'public,max-age=%d' \
-            % EXPIRATION_TIME
+        self.response.headers['Cache-Control'] = 'public,max-age={0:d}'.format(EXPIRATION_TIME)
         self.response.write(data)
 
     def delete(self, content_type, data_hash, file_name):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:hoangphantich:webeula16.1?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:hoangphantich:webeula16.1?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hoangphantich/webeula16.1/22)

<!-- Reviewable:end -->
